### PR TITLE
JSON Serialization and Deserialization - Part 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20201115</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/marginallyClever/nodeGraphCore/JSONHelper.java
+++ b/src/main/java/com/marginallyClever/nodeGraphCore/JSONHelper.java
@@ -1,25 +1,199 @@
 package com.marginallyClever.nodeGraphCore;
 
-import org.json.JSONObject;
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import com.marginallyClever.nodeGraphCore.json.NodeGraphJsonAdapter;
+import com.marginallyClever.nodeGraphCore.json.NodeJsonAdapter;
 
 import java.awt.*;
+import java.lang.reflect.Type;
+import java.util.Collection;
 
 public class JSONHelper {
-    public static JSONObject rectangleToJSON(Rectangle rectangle) {
-        JSONObject r = new JSONObject();
-        r.put("x",rectangle.x);
-        r.put("y",rectangle.y);
-        r.put("width",rectangle.width);
-        r.put("height",rectangle.height);
-        return r;
+
+    private static GsonBuilder builder;
+    private static Gson gson;
+
+    public static Gson getDefaultGson(){
+        if(gson == null){
+            gson = getDefaultGsonBuilder().create();
+        }
+        return gson;
     }
 
-    public static Rectangle rectangleFromJSON(JSONObject r) {
-        Rectangle rect = new Rectangle();
-        rect.x = r.getInt("x");
-        rect.y = r.getInt("y");
-        rect.width = r.getInt("width");
-        rect.height = r.getInt("height");
-        return rect;
+    public static GsonBuilder getDefaultGsonBuilder(){
+        if(builder == null){
+            builder = new GsonBuilder();
+            builder.setPrettyPrinting();
+            registerTypeAdapters(builder);
+        }
+        return builder;
     }
+
+    public static void registerTypeAdapters(GsonBuilder builder){
+        builder.registerTypeAdapter(NodeGraph.class, new NodeGraphJsonAdapter());
+        builder.registerTypeHierarchyAdapter(Node.class, new NodeJsonAdapter());
+    }
+
+    /**
+     * Creates a deep copy of the given {@link NodeGraph} using json serialization/deserialization
+     * @param graph the {@link NodeGraph} to copy
+     * @return the {@link NodeGraph} copy
+     */
+    public static NodeGraph deepCopy(NodeGraph graph){
+        JsonElement jsonElement = JSONHelper.getDefaultGson().toJsonTree(graph);
+        return JSONHelper.getDefaultGson().fromJson(jsonElement, NodeGraph.class);
+    }
+
+    /**
+     * Creates a deep copy of the given {@link Node} using json serialization/deserialization
+     * @param source the {@link NodeGraph} to copy
+     * @return the {@link NodeGraph} copy
+     */
+    public static Node deepCopy(Node source){
+        JsonElement jsonElement = JSONHelper.getDefaultGson().toJsonTree(source);
+        return JSONHelper.getDefaultGson().fromJson(jsonElement, Node.class);
+    }
+
+    /**
+     * Used for serializing a {@link Collection} of {@link NodeConnection}s to a {@link JsonElement}
+     * @param nodeConnections the {@link Collection} of {@link NodeConnection}s to serialize
+     * @return a {@link JsonElement} representing the list of {@link NodeConnection}s
+     */
+    public static JsonElement serializeNodeConnections(Collection<NodeConnection> nodeConnections){
+        JsonArray jsonArray = new JsonArray();
+        for(NodeConnection connection : nodeConnections){
+            jsonArray.add(serializeNodeConnection(connection));
+        }
+        return jsonArray;
+    }
+
+    /**
+     * Used for serializing a {@link Collection} of {@link NodeConnection}s from a {@link JsonElement}
+     * @param jsonElement the {@link JsonElement} to read the {@link Collection} of {@link NodeConnection}s from
+     * @param dstGraph the destination {@link NodeGraph}, where the connections will be added
+     */
+    public static void deserializeNodeConnections(JsonElement jsonElement, NodeGraph dstGraph){
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        for(JsonElement e : jsonArray) {
+            dstGraph.add(deserializeNodeConnection(e, dstGraph));
+        }
+    }
+
+    /**
+     * Used for serializing a single {@link NodeConnection} to a {@link JsonElement}
+     * @param connection the {@link NodeConnection} to serialize
+     * @return a {@link JsonElement} representing the {@link NodeConnection}
+     */
+    public static JsonElement serializeNodeConnection(NodeConnection connection){
+        JsonObject jsonObject = new JsonObject();
+        if(connection.getInNode() != null) {
+            jsonObject.addProperty("inNode", connection.getInNode().getUniqueName());
+            jsonObject.addProperty("inVariableIndex", connection.getInVariableIndex());
+        }
+        if(connection.getOutNode() != null) {
+            jsonObject.addProperty("outNode", connection.getOutNode().getUniqueName());
+            jsonObject.addProperty("outVariableIndex", connection.getOutVariableIndex());
+        }
+        return jsonObject;
+    }
+
+    /**
+     * Used for de-serializing a single {@link NodeConnection} from a {@link JsonElement}.
+     * This method only performs the deserialization and doesn't add the connection to the graph, that is handled by {@link #deserializeNodeConnections}
+     *
+     * @param jsonElement the {@link JsonElement} to de-serialize the {@link NodeConnection} from
+     * @param dstGraph the destination {@link NodeGraph}
+     * @return the {@link NodeConnection}
+     */
+    public static NodeConnection deserializeNodeConnection(JsonElement jsonElement, NodeGraph dstGraph){
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        NodeConnection connection = new NodeConnection();
+
+        if(jsonObject.has("inNode")) {
+            Node n = dstGraph.findNodeWithUniqueName(jsonObject.get("inNode").getAsString());
+            int i = jsonObject.get("inVariableIndex").getAsInt();
+            connection.setInput(n,i);
+        }
+        if(jsonObject.has("outNode")) {
+            Node n = dstGraph.findNodeWithUniqueName(jsonObject.get("outNode").getAsString());
+            int i = jsonObject.get("outVariableIndex").getAsInt();
+            connection.setOutput(n,i);
+        }
+
+        return connection;
+    }
+
+    /**
+     * Used for serializing a {@link Collection} of {@link NodeVariable}s to a {@link JsonElement}
+     * @param variables the {@link Collection} of {@link NodeVariable}s to serialize
+     * @return a {@link JsonElement} representing the {@link Collection} of {@link NodeVariable}
+     */
+    public static JsonElement serializeNodeVariables(Collection<NodeVariable<?>> variables){
+        JsonArray jsonArray = new JsonArray();
+        for(NodeVariable<?> variable : variables){
+            jsonArray.add(serializeNodeVariable(variable));
+        }
+        return jsonArray;
+    }
+
+    /**
+     * Used for de-serializing a {@link Collection} of {@link NodeVariable}s to a {@link JsonElement}
+     * @param variables the {@link Collection} of {@link NodeVariable}s to deserialize into, MUST contain all of the {@link NodeVariable}s required already.
+     * @param jsonElement the element to de-serialize the nodes from
+     */
+    public static void deserializeNodeVariables(Collection<NodeVariable<?>> variables, JsonElement jsonElement){
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+
+        for(JsonElement e : jsonArray){
+            JsonObject jsonObject = e.getAsJsonObject();
+            String variableName = jsonObject.get("name").getAsString();
+
+            NodeVariable<?> variable = null;
+
+            for(NodeVariable<?> v : variables){
+                if(v.getName().equals(variableName)){
+                    variable = v;
+                    break;
+                }
+            }
+
+            if(variable == null){
+                continue;
+            }
+            deserializeNodeVariable(variable, e);
+        }
+    }
+
+    /**
+     * Used for serializing a single {@link NodeVariable} to a {@link JsonElement}
+     * @param variable the {@link NodeVariable}s to serialize
+     * @return a {@link JsonElement} representing the {@link NodeVariable}
+     */
+    public static JsonElement serializeNodeVariable(NodeVariable<?> variable){
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.add("value", getDefaultGson().toJsonTree(variable.getValue(), variable.getTypeClass()));
+        jsonObject.addProperty("name", variable.getName());
+        jsonObject.addProperty("hasInput", variable.getHasInput());
+        jsonObject.addProperty("hasOutput", variable.getHasOutput());
+        jsonObject.add("bounds", getDefaultGson().toJsonTree(variable.getRectangle(), Rectangle.class));
+        jsonObject.addProperty("isDirty", variable.getIsDirty());
+        return jsonObject;
+    }
+
+    /**
+     * Used for de-serializing a single {@link NodeVariable} from a {@link JsonElement}
+     * @param variable the {@link NodeVariable}s to deserialize into
+     * @param jsonElement the element to de-serialize the nodes from
+     */
+    public static void deserializeNodeVariable(NodeVariable<?> variable, JsonElement jsonElement){
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        variable.setValue(getDefaultGson().fromJson(jsonObject.get("value"), variable.getTypeClass())); //important: set the value first, otherwise isDirty will be overwritten
+        variable.name = jsonObject.get("name").getAsString();
+        variable.hasInput = jsonObject.get("hasInput").getAsBoolean();
+        variable.hasOutput = jsonObject.get("hasOutput").getAsBoolean();
+        variable.rectangle.setBounds(getDefaultGson().fromJson(jsonObject.get("bounds"), Rectangle.class));
+        variable.isDirty = jsonObject.get("isDirty").getAsBoolean();
+    }
+
 }

--- a/src/main/java/com/marginallyClever/nodeGraphCore/NodeConnection.java
+++ b/src/main/java/com/marginallyClever/nodeGraphCore/NodeConnection.java
@@ -1,8 +1,5 @@
 package com.marginallyClever.nodeGraphCore;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.awt.*;
 import java.util.Objects;
 
@@ -112,19 +109,6 @@ public class NodeConnection {
                 '}';
     }
 
-    public JSONObject toJSON() throws JSONException {
-        JSONObject jo = new JSONObject();
-        if(inNode!=null) {
-            jo.put("inNode",inNode.getUniqueName());
-            jo.put("inVariableIndex",inVariableIndex);
-        }
-        if(outNode!=null) {
-            jo.put("outNode", outNode.getUniqueName());
-            jo.put("outVariableIndex", outVariableIndex);
-        }
-        return jo;
-    }
-
     // the in position of this {@link NodeConnection} is the out position of a {@link NodeVariable}
     public Point getInPosition() {
         return inNode.getOutPosition(inVariableIndex);
@@ -165,6 +149,14 @@ public class NodeConnection {
     @Override
     public int hashCode() {
         return Objects.hash(inNode, inVariableIndex, outNode, outVariableIndex);
+    }
+
+    public int getInVariableIndex() {
+        return inVariableIndex;
+    }
+
+    public int getOutVariableIndex() {
+        return outVariableIndex;
     }
 
     public NodeVariable<?> getInVariable() {

--- a/src/main/java/com/marginallyClever/nodeGraphCore/NodeVariable.java
+++ b/src/main/java/com/marginallyClever/nodeGraphCore/NodeVariable.java
@@ -1,9 +1,5 @@
 package com.marginallyClever.nodeGraphCore;
 
-import com.marginallyClever.nodeGraphCore.JSONHelper;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.awt.*;
 
 /**
@@ -15,15 +11,15 @@ public class NodeVariable<T> {
     public static final int DEFAULT_WIDTH = 150;
     public static final int DEFAULT_HEIGHT = 20;
 
-    private T value;
-    private final Class<T> type;
+    protected T value;
+    protected final Class<T> type;
 
-    private String name;
-    private boolean hasInput;
-    private boolean hasOutput;
+    protected String name;
+    protected boolean hasInput;
+    protected boolean hasOutput;
 
-    private boolean isDirty;
-    private final Rectangle rectangle = new Rectangle();
+    protected boolean isDirty;
+    protected final Rectangle rectangle = new Rectangle();
 
     private NodeVariable(String _name,Class<T> type,T defaultValue,boolean _hasInput,boolean _hasOutput) {
         super();
@@ -64,7 +60,11 @@ public class NodeVariable<T> {
         }
     }
 
-    public String getTypeClass() {
+    public Class<T> getTypeClass() {
+        return type;
+    }
+
+    public String getTypeName() {
         return type.getSimpleName();
     }
 
@@ -95,27 +95,6 @@ public class NodeVariable<T> {
                 '}';
     }
 
-    public JSONObject toJSON() throws JSONException {
-        JSONObject jo = new JSONObject();
-        jo.put("value",value);
-        jo.put("name",name);
-        jo.put("hasInput",hasInput);
-        jo.put("hasOutput",hasOutput);
-        jo.put("rectangle", JSONHelper.rectangleToJSON(rectangle));
-        jo.put("isDirty",isDirty);
-        return jo;
-    }
-
-    @SuppressWarnings("unchecked")
-    public void parseJSON(JSONObject jo) throws JSONException, ClassCastException {
-        value = (jo.has("value") ? (T)jo.get("value") : null);
-        name = jo.getString("name");
-        hasInput = jo.getBoolean("hasInput");
-        hasOutput = jo.getBoolean("hasOutput");
-        rectangle.setBounds(JSONHelper.rectangleFromJSON(jo.getJSONObject("rectangle")));
-        isDirty = jo.getBoolean("isDirty");
-    }
-
     public boolean getHasOutput() {
         return hasOutput;
     }
@@ -131,4 +110,7 @@ public class NodeVariable<T> {
     public Point getOutPosition() {
         return new Point((int)rectangle.getMaxX(), rectangle.y+rectangle.height/2);
     }
+
+
+
 }

--- a/src/main/java/com/marginallyClever/nodeGraphCore/json/NodeGraphJsonAdapter.java
+++ b/src/main/java/com/marginallyClever/nodeGraphCore/json/NodeGraphJsonAdapter.java
@@ -1,0 +1,45 @@
+package com.marginallyClever.nodeGraphCore.json;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import com.marginallyClever.nodeGraphCore.JSONHelper;
+import com.marginallyClever.nodeGraphCore.Node;
+import com.marginallyClever.nodeGraphCore.NodeConnection;
+import com.marginallyClever.nodeGraphCore.NodeGraph;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NodeGraphJsonAdapter implements JsonSerializer<NodeGraph>, JsonDeserializer<NodeGraph> {
+
+    public static final Type nodeType = TypeToken.getParameterized(ArrayList.class, Node.class).getType();
+
+    @Override
+    public JsonElement serialize(NodeGraph nodeGraph, Type type, JsonSerializationContext context) {
+        JsonObject jsonObject = new JsonObject();
+
+        JsonElement nodes = context.serialize(nodeGraph.getNodes(), nodeType);
+        jsonObject.add("nodes", nodes);
+
+        jsonObject.add("connections", JSONHelper.serializeNodeConnections(nodeGraph.getConnections()));
+        return jsonObject;
+    }
+
+    @Override
+    public NodeGraph deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        NodeGraph nodeGraph = new NodeGraph();
+
+        List<Node> nodes = context.deserialize(jsonObject.get("nodes"), nodeType);
+        nodes.forEach(nodeGraph::add);
+
+        JSONHelper.deserializeNodeConnections(jsonObject.get("connections"), nodeGraph);
+
+        nodeGraph.bumpUpIndexableID();
+
+        return nodeGraph;
+    }
+
+}

--- a/src/main/java/com/marginallyClever/nodeGraphCore/json/NodeJsonAdapter.java
+++ b/src/main/java/com/marginallyClever/nodeGraphCore/json/NodeJsonAdapter.java
@@ -1,0 +1,39 @@
+package com.marginallyClever.nodeGraphCore.json;
+
+import com.google.gson.*;
+import com.marginallyClever.nodeGraphCore.Node;
+import com.marginallyClever.nodeGraphCore.NodeFactory;
+import com.marginallyClever.nodeGraphCore.JSONHelper;
+
+import java.awt.*;
+import java.lang.reflect.Type;
+
+public class NodeJsonAdapter implements JsonSerializer<Node>, JsonDeserializer<Node> {
+
+    @Override
+    public JsonElement serialize(Node node, Type type, JsonSerializationContext context) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("name", node.getName());
+        jsonObject.addProperty("uniqueID", node.getUniqueID());
+        jsonObject.addProperty("label", node.getLabel());
+        jsonObject.add("bounds", context.serialize(node.getRectangle(), Rectangle.class));
+        jsonObject.add("variables", JSONHelper.serializeNodeVariables(node.getVariables()));
+        return jsonObject;
+    }
+
+    @Override
+    public Node deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        String name = jsonObject.get("name").getAsString();
+
+        Node node = NodeFactory.createNode(name);
+        if(node != null){
+            node.setUniqueID(jsonObject.get("uniqueID").getAsInt());
+            node.setLabel(jsonObject.get("label").getAsString());
+            node.setRectangle(context.deserialize(jsonObject.get("bounds"), Rectangle.class));
+            JSONHelper.deserializeNodeVariables(node.getVariables(), jsonObject.get("variables"));
+            return node;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/marginallyClever/nodeGraphSwing/NodeEditPanel.java
+++ b/src/main/java/com/marginallyClever/nodeGraphSwing/NodeEditPanel.java
@@ -1,5 +1,6 @@
 package com.marginallyClever.nodeGraphSwing;
 
+import com.marginallyClever.nodeGraphCore.JSONHelper;
 import com.marginallyClever.nodeGraphCore.Node;
 import com.marginallyClever.nodeGraphCore.NodeVariable;
 import com.marginallyClever.nodeGraphCore.builtInNodes.math.Add;
@@ -35,7 +36,7 @@ public class NodeEditPanel extends JPanel {
 
     private void addTextField(NodeVariable<?> variable,GridBagConstraints c) {
         c.gridx=0;  this.add(new JLabel(variable.getName()),c);
-        c.gridx=1;  this.add(new JLabel(variable.getTypeClass()),c);
+        c.gridx=1;  this.add(new JLabel(variable.getTypeName()),c);
         JTextField textField = new JTextField(variable.getValue().toString());
         c.gridx=2;  this.add(textField,c);
         c.gridy++;
@@ -79,9 +80,7 @@ public class NodeEditPanel extends JPanel {
     }
 
     private static Node deepCopy(Node subject) {
-        Node newNode = subject.create();
-        newNode.parseJSON(subject.toJSON());
-        return newNode;
+        return JSONHelper.deepCopy(subject);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/marginallyClever/nodeGraphSwing/NodeGraphEditorPanel.java
+++ b/src/main/java/com/marginallyClever/nodeGraphSwing/NodeGraphEditorPanel.java
@@ -361,8 +361,8 @@ public class NodeGraphEditorPanel extends JPanel {
             } else {
                 NodeVariable<?> vIn = connectionBeingCreated.getInVariable();
                 NodeVariable<?> vOut = connectionBeingCreated.getOutVariable();
-                String nameIn = (vIn==null) ? "null" : vIn.getTypeClass();
-                String nameOut = (vOut==null) ? "null" : vOut.getTypeClass();
+                String nameIn = (vIn==null) ? "null" : vIn.getTypeName();
+                String nameOut = (vOut==null) ? "null" : vOut.getTypeName();
                 System.out.println("Invalid types "+nameOut+", "+nameIn+".");
             }
             // if any of the tests failed, restart.

--- a/src/main/java/com/marginallyClever/nodeGraphSwing/actions/ActionLoadGraph.java
+++ b/src/main/java/com/marginallyClever/nodeGraphSwing/actions/ActionLoadGraph.java
@@ -1,8 +1,8 @@
 package com.marginallyClever.nodeGraphSwing.actions;
 
+import com.marginallyClever.nodeGraphCore.JSONHelper;
 import com.marginallyClever.nodeGraphCore.NodeGraph;
 import com.marginallyClever.nodeGraphSwing.NodeGraphEditorPanel;
-import org.json.JSONObject;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -29,17 +29,17 @@ public class ActionLoadGraph extends AbstractAction {
     }
 
     private NodeGraph loadModelFromFile(String absolutePath) {
-        NodeGraph newModel = new NodeGraph();
+        NodeGraph newModel;
         try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(absolutePath)))) {
             StringBuilder responseStrBuilder = new StringBuilder();
             String inputStr;
             while ((inputStr = reader.readLine()) != null)
                 responseStrBuilder.append(inputStr);
-            JSONObject modelAsJSON = new JSONObject(responseStrBuilder.toString());
-            newModel.parseJSON(modelAsJSON);
+            newModel = JSONHelper.getDefaultGson().fromJson(responseStrBuilder.toString(), NodeGraph.class);
         } catch(IOException e) {
             JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(editor),e.getLocalizedMessage());
             e.printStackTrace();
+            newModel = new NodeGraph();
         }
         return newModel;
     }

--- a/src/main/java/com/marginallyClever/nodeGraphSwing/actions/ActionSaveGraph.java
+++ b/src/main/java/com/marginallyClever/nodeGraphSwing/actions/ActionSaveGraph.java
@@ -1,5 +1,6 @@
 package com.marginallyClever.nodeGraphSwing.actions;
 
+import com.marginallyClever.nodeGraphCore.JSONHelper;
 import com.marginallyClever.nodeGraphSwing.NodeGraphEditorPanel;
 
 import javax.swing.*;
@@ -36,7 +37,7 @@ public class ActionSaveGraph extends AbstractAction {
 
     private void saveModelToFile(String absolutePath) {
         try(BufferedWriter w = new BufferedWriter(new FileWriter(absolutePath))) {
-            w.write(editor.getGraph().toJSON().toString());
+            w.write(JSONHelper.getDefaultGson().toJson(editor.getGraph()));
         } catch(Exception e) {
             JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(editor),e.getLocalizedMessage());
             e.printStackTrace();

--- a/src/test/java/com/marginallyClever/nodeGraphSwing/TestNodeGraphSwing.java
+++ b/src/test/java/com/marginallyClever/nodeGraphSwing/TestNodeGraphSwing.java
@@ -1,20 +1,8 @@
 package com.marginallyClever.nodeGraphSwing;
 
 import com.marginallyClever.nodeGraphCore.*;
-import com.marginallyClever.nodeGraphCore.builtInNodes.LoadNumber;
-import com.marginallyClever.nodeGraphCore.builtInNodes.PrintToStdOut;
-import com.marginallyClever.nodeGraphCore.builtInNodes.math.Add;
-import com.marginallyClever.nodeGraphCore.builtInNodes.math.Multiply;
-import com.marginallyClever.nodeGraphCore.builtInNodes.math.Subtract;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.InvocationTargetException;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class TestNodeGraphSwing {
     private static NodeGraph model;


### PR DESCRIPTION
- Moved all JSON related methods into the JSONHelper
- Simplified some JSON
- When serializing variables, the JSON Helper will use the variables name instead of it's index, allowing for variables to be rearranged removed/added to the node in the future and still be serialized properly. I would propose seperately that we enforce unique variable names, and potentially store them in a hash map.
- This is Part 1 of the commit, which uses the current data structure, part 2, would suggest a few new versions of the classes to allow arbitrary serialization.
An example of this is partially working for Node and NodeGraph as they both already have JsonAdapters, which allow them to be parsed to json regardless of where they are in the data structure. Whereas NodeConnection and NodeVariable can only be parsed when a Node / Graph is present which means they can't be serialized everywhere.

- Note I made bumpUpIndexableID public, obviously not a good idea for now, but I'll post my suggestion for this in another PR.